### PR TITLE
demoapp listening address more wider, required to dockerized solution. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,11 @@ If the application was started by double-clicking ``demoapp/server.py``
 file, it can be shut down by closing the opened window. If it was
 executed from the command line, using ``Ctrl-C`` is enough.
 
+OR with docker-compose:
+Start to backround: `docker-compose up -d`
+Stop: `docker-compose down`
+
+
 Running tests
 -------------
 

--- a/demoapp/Dockerfile
+++ b/demoapp/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:alpine
+COPY ./ /demoapp/
+EXPOSE 7272
+RUN chmod +x /demoapp/server.py
+ENTRYPOINT [ "/demoapp/server.py" ]

--- a/demoapp/server.py
+++ b/demoapp/server.py
@@ -34,7 +34,7 @@ class DemoServer(ThreadingMixIn, HTTPServer):
     allow_reuse_address = True
 
     def __init__(self, port=PORT):
-        HTTPServer.__init__(self, ('localhost', int(port)),
+        HTTPServer.__init__(self, ('0.0.0.0', int(port)),
                             SimpleHTTPRequestHandler)
 
     def serve(self, directory=ROOT):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  webdemo:
+    build:
+      context: ./demoapp
+      dockerfile: Dockerfile
+    ports:
+      - '7272:7272'


### PR DESCRIPTION
Demoapp listening address chanced to more wider: localhost => 0.0.0.0
In docker container call come over ip so localhost not work.
Added dockerized solution of demoapp that benefit is that it goes backround automaticly.
